### PR TITLE
correct course name, meeting times, mediaspace link

### DIFF
--- a/forensics/readme.md
+++ b/forensics/readme.md
@@ -1,6 +1,6 @@
-# CS 410/510: System Administration and DevOps
+# CS 493/593: Digital Forensics
 
-**Location**: FAB 150 (TR 16:40-18:30)
+**Location**: FAB 46 (MW 16:40-18:30)
 
 **Instructor**: D. Kevin McGrath
 
@@ -13,7 +13,8 @@
 
 **[Syllabus](syllabus.md)**
 
-**Recorded Lectures**: These will be made available via [MediaSpace](https://media.pdx.edu/channel/CS410_510%2BSystem%2BAdministration%2Band%2BDevops/319613112). Login required.
+<!-- incorrect link, could not find correct one via mediaspace search -->
+<!-- **Recorded Lectures**: These will be made available via [MediaSpace](https://media.pdx.edu/channel/CS410_510%2BSystem%2BAdministration%2Band%2BDevops/319613112). Login required. --> 
 
 <!-- **Zulip Org**: [Zulip](https://netsec.zulip.cs.pdx.edu/) -->
 

--- a/forensics/syllabus.md
+++ b/forensics/syllabus.md
@@ -1,6 +1,6 @@
 # CS493/593: Digital Forensics
 
-**Location**: FAB 46 (MW 14:00-15:50)
+**Location**: FAB 46 (MW 16:40-18:30)
 
 **Instructor**: D. Kevin McGrath
 
@@ -17,7 +17,8 @@
     * Location: TBD
     * Times: TBD
 
-**Recorded Lectures**: These will be made available via [MediaSpace](https://media.pdx.edu/channel/channelid/328503742). Login required.
+<!-- incorrect link, could not find correct one via mediaspace search -->
+<!-- **Recorded Lectures**: These will be made available via [MediaSpace](https://media.pdx.edu/channel/channelid/328503742). Login required. -->
 
 <!-- **Zulip Org**: [Zulip](https://netsec.zulip.cs.pdx.edu/) -->
 


### PR DESCRIPTION
I updated the course name and meeting times.

I commented out the incorrect mediaspace links since I reckon no link is better than a wrong link. Sorry if this is annoying.

My Vim added a newline to syllabus.md automatically :)